### PR TITLE
Enable ReadTheDocs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,7 @@
+python:
+    version: 3
+    # only use the packages specified in setup.py
+    use_system_site_packages: false
+    pip_install: true
+    extra_requirements:
+        - doc


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

I've created a ReadTheDocs project for this repo (https://readthedocs.org/projects/solarfactors/) and enabled PR builds.  This PR just adds a configuration file (copied from pvlib-python).
