### PR TITLE
Set up for initial release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,25 @@
+pvlib/solarfactors: a fork of SunPower/pvfactors
+================================================
+
+This repository is a fork of `SunPower/solarfactors <https://github.com/sunpower/pvfactors>`_,
+a 2-D view factor model for simulating front- and rear-side irradiance for
+bifacial PV systems.
+
+This fork exists so that the pvfactors model can continue to be used with
+`pvlib python <https://github.com/pvlib/pvlib-python>`_ even though the original
+repository is no longer maintained.  The objective is to provide a working
+dependency for the existing pvfactors functionality currently in pvlib python.
+New features may be added, but don't count on it.
+
+Documentation for this fork can be found at `Read The Docs <https://solarfactors.readthedocs.io>`_.
+
+The project can be installed from PyPI using ``pip install solarfactors``.  Note
+that the package is still used from python under the ``pvfactors`` name, i.e.
+with ``from pvfactors.geometry import OrderedPVArray``.
+
+The original ``pvfactors`` is preserved below:
+
+
 pvfactors: irradiance modeling made simple
 ==========================================
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -48,10 +48,12 @@ extensions = [
     'sphinx.ext.coverage',
     'nbsphinx',
     'sphinx.ext.napoleon',
+    'sphinx.ext.extlinks',
     'sphinxcontrib_github_alt'
 ]
 
-# For sphinxcontrib_github_alt
+# For sphinxcontrib_github_alt.  keep this as the original repo for old links
+# (since new links use extlinks instead of this)
 github_project_url = "https://github.com/SunPower/pvfactors"
 
 # Add any paths that contain templates here, relative to this directory.
@@ -69,9 +71,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'pvfactors'
-copyright = u'2016, SunPower Corporation'
-author = u'SunPower Corporation'
+project = u'solarfactors'
+copyright = u'2016, SunPower Corporation and pvlib python Developers'
+author = u'SunPower Corporation and pvlib python Developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -135,8 +137,8 @@ html_theme = 'sphinx_rtd_theme'
 
 html_context = {
     'display_github': True,
-    'github_user': 'SunPower',
-    'github_repo': 'pvfactors'
+    'github_user': 'pvlib',
+    'github_repo': 'solarfactors'
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -146,7 +148,7 @@ html_theme_options = {}
 
 # Make sure the "Edit on Github" link is not broken
 rst_prolog = """
-:github_url: https://github.com/SunPower/pvfactors/
+:github_url: https://github.com/pvlib/solarfactors/
 
 """
 
@@ -336,3 +338,11 @@ autosummary_generate = True
 
 def setup(app):
     app.add_css_file('css/custom.css')
+
+
+extlinks = {
+    'issue': ('https://github.com/pvlib/solarfactors/issues/%s', 'GH'),
+    'pull': ('https://github.com/pvlib/solarfactors/pull/%s', 'GH'),
+    'doi': ('http://dx.doi.org/%s', 'DOI: '),
+    'ghuser': ('https://github.com/%s', '@')
+}

--- a/docs/sphinx/whatsnew.rst
+++ b/docs/sphinx/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v1.5.3.rst
 .. include:: whatsnew/v1.5.2.rst
 .. include:: whatsnew/v1.5.1.rst
 .. include:: whatsnew/v1.5.0.rst

--- a/docs/sphinx/whatsnew/v1.5.3.rst
+++ b/docs/sphinx/whatsnew/v1.5.3.rst
@@ -1,22 +1,19 @@
 .. _whatsnew_153:
 
-v1.5.3 (TBD)
+v1.5.3 (June 30, 2023)
 ======================
+
+This is the first release of the ``solarfactors`` fork.  It is functionally
 
 Installation
 ------------
 * The ``docs`` and ``testing`` extras in ``setup.py`` are now called ``doc`` and ``test`` (:pull:`1`)
 
-Enhancements
-------------
-
 
 Requirements
 ------------
+* Removed the upper version limit on ``pvlib`` (:pull:`5`)
 
-
-Bug Fixes
-----------
 
 Testing
 -------
@@ -28,4 +25,4 @@ Testing
 
 Contributors
 ------------
-* Kevin Anderson (:ghuser:`kanderso-nrel`)
+* Kevin Anderson (:ghuser:`kandersolar`)

--- a/docs/sphinx/whatsnew/v1.5.3.rst
+++ b/docs/sphinx/whatsnew/v1.5.3.rst
@@ -3,7 +3,7 @@
 v1.5.3 (June 30, 2023)
 ======================
 
-This is the first release of the ``solarfactors`` fork.  It is functionally
+This is the first release of the ``solarfactors`` fork.
 
 Installation
 ------------

--- a/pvfactors/tests/test_geometry/test_pvarray.py
+++ b/pvfactors/tests/test_geometry/test_pvarray.py
@@ -133,7 +133,7 @@ def test_ordered_pvarray_gnd_shadow_casting(params):
     ordered_pvarray = OrderedPVArray.fit_from_dict_of_scalars(params)
     assert len(ordered_pvarray.ts_ground.non_point_shaded_surfaces_at(0)) == 3
     assert len(ordered_pvarray.ts_ground.non_point_illum_surfaces_at(0)) == 7
-    assert ordered_pvarray.ts_ground.shaded_length == 6.385066634855473
+    assert ordered_pvarray.ts_ground.shaded_length.round(3) == 6.385
 
 
 def _check_ground_surfaces(ts_ground, expected_n_shadow_surfaces,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pvlib>=0.9.0,<0.10.0
+pvlib>=0.9.0
 shapely>=1.6.4.post2,<2
 matplotlib
 future

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ with open('README.rst', 'r') as f:
 with open('requirements.txt', 'r') as f:
     INSTALL_REQUIRES = list(f)
 
-DISTNAME = 'pvfactors'
-AUTHOR = 'SunPower'
-MAINTAINER_EMAIL = 'marc.abouanoma@sunpowercorp.com'
-URL = 'https://github.com/SunPower/pvfactors'
+DISTNAME = 'solarfactors'
+AUTHOR = 'SunPower and pvlib python Developers'
+MAINTAINER_EMAIL = 'pvlib-admin@googlegroups.com'
+URL = 'https://github.com/pvlib/solarfactors'
 PACKAGES = ['pvfactors', 'pvfactors.geometry', 'pvfactors.irradiance',
             'pvfactors.viewfactors']
 LICENSE = 'BSD 3-Clause'
@@ -24,7 +24,6 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

This PR sets up this project for the initial release to PyPI.  Except for some documentation and test/doc stuff, it is functionally equivalent to pvfactors version 1.5.2.  The one exception is that it has no upper version limit on its pvlib dependency.  This is necessary to address https://github.com/pvlib/pvlib-python/issues/1796.

The way it is currently configured, it will be listed on PyPI under `solarfactors` but the installed python package is still imported with `pvfactors`.  I am still nervous about this approach (see https://github.com/pvlib/pvlib-python/discussions/1657#discussioncomment-4938209), but it is the easiest and fastest way to resolving https://github.com/pvlib/pvlib-python/issues/1796.

For consistency I think it makes sense to continue on with the versioning used in the original pvfactors, so this release will be 1.5.3.  