### PR TITLE
Update readthedocs config

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,13 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"
+
 python:
-    version: 3
-    # only use the packages specified in setup.py
-    use_system_site_packages: false
-    pip_install: true
-    extra_requirements:
-        - doc
+    install:
+        - method: pip
+          path: .
+          extra_requirements:
+              - doc


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
 - [x] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

RTD doesn't like this project's configuration file.  See the warnings on this build: https://readthedocs.org/projects/solarfactors/builds/21172217/

> Your builds will stop working soon!
> "build.image" config key is deprecated and it will be removed soon. [Read our blog post to know how to migrate to new key "build.os"](https://blog.readthedocs.com/use-build-os-config/) and ensure your project continues building successfully.

> Your builds will stop working soon!
> Configuration files will soon be required by projects, and will no longer be optional. [Read our blog post to create one](https://blog.readthedocs.com/migrate-configuration-v2/) and ensure your project continues building successfully.

This PR updates the configuration file to the current recommended state.