### PR TITLE
Fix lint issues from #22

### DIFF
--- a/pvfactors/geometry/pvrow.py
+++ b/pvfactors/geometry/pvrow.py
@@ -5,7 +5,7 @@ from shapely.ops import unary_union, linemerge
 from pvfactors.config import COLOR_DIC
 from pvfactors.geometry.base import \
     BaseSide, _coords_from_center_tilt_length, PVSegment
-from shapely.geometry import GeometryCollection, LineString
+from shapely.geometry import LineString
 from pvfactors.geometry.timeseries import \
     TsShadeCollection, TsLineCoords, TsSurface
 from pvlib.tools import cosd, sind
@@ -708,10 +708,6 @@ class PVRow:
     def length(self):
         """Length of the PV row."""
         return self.front.length + self.back.length
-
-    @property
-    def boundary(self):
-        return self._linestring.boundary
 
     def intersects(self, line):
         """Check if the PV row intersects with a line.

--- a/pvfactors/viewfactors/vfmethods.py
+++ b/pvfactors/viewfactors/vfmethods.py
@@ -240,7 +240,7 @@ class VFTsMethods(object):
                         surf_i.coords, surf_j.coords, length_i)
                     vf_i_to_j = np.where(tilted_to_left, vf_i_to_j, 0.)
                     vf_j_to_i = np.divide(
-                        vf_i_to_j * length_i , length_j,
+                        vf_i_to_j * length_i, length_j,
                         where=length_j > DISTANCE_TOLERANCE,
                         out=np.zeros_like(length_j))
                     vf_matrix[i, j, :] = vf_i_to_j


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] I am familiar with the [contributing guidelines](https://pvlib-python.readthedocs.io/en/latest/contributing.html)
 - [ ] Tests added
 - [ ] Updates entries in [`docs/sphinx/source/reference`](https://github.com/pvlib/pvlib-python/blob/main/docs/sphinx/source/reference) for API changes.
 - [ ] Adds description and name entries in the appropriate "what's new" file in [`docs/sphinx/source/whatsnew`](https://github.com/pvlib/pvlib-python/tree/main/docs/sphinx/source/whatsnew) for all changes. Includes link to the GitHub Issue with `` :issue:`num` `` or this Pull Request with `` :pull:`num` ``. Includes contributor name and/or GitHub username (link with `` :ghuser:`user` ``).
 - [ ] New code is fully documented. Includes [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant docstrings, examples, and comments where necessary.
 - [ ] Pull request is nearly complete and ready for detailed review.
 - [ ] Maintainer: Appropriate GitHub Labels (including `remote-data`) and Milestone are assigned to the Pull Request and linked Issue.

Fixes a few linter issues from #22:

```$ flake8 . --count --max-line-length=99 --statistics
./pvfactors/geometry/pvrow.py:8:1: F401 'shapely.geometry.GeometryCollection' imported but unused
./pvfactors/geometry/pvrow.py:844:5: F811 redefinition of unused 'boundary' from line 713
./pvfactors/viewfactors/vfmethods.py:243:45: E203 whitespace before ','
1     E203 whitespace before ','
1     F401 'shapely.geometry.GeometryCollection' imported but unused
1     F811 redefinition of unused 'boundary' from line 713
3
```
