### PR TITLE
Drop python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel other matrix jobs when one fails
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/docs/sphinx/whatsnew/v1.6.1.rst
+++ b/docs/sphinx/whatsnew/v1.6.1.rst
@@ -6,7 +6,7 @@ v1.6.1 (??)
 
 Maintenance
 -----------
-* Drop Python 3.8 support (:pull:`30`)
+* Drop Python 3.8 and 3.9 support (:pull:`30`, :pull:`33`)
 
 
 Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,13 @@ classifiers = [
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pvlib>=0.9.0",
     "shapely>=2.0",


### PR DESCRIPTION
Python 3.9 reaches end-of-life in October 2025: https://devguide.python.org/versions/